### PR TITLE
add simulateFill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ package-lock.json
 
 dbs/
 dazaar-ema-feed.json
+examples/dbs/

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,1 +1,5 @@
+# 1.1.0
+ - add initialFill property
 
+# 1.0.0
+ - initial implementation

--- a/examples/example_ema_dazaar_sell.js
+++ b/examples/example_ema_dazaar_sell.js
@@ -125,7 +125,7 @@ async.auto({
 
     const { exec, stream } = await execDazaar(strategy, market, db, {
       submitOrder,
-
+      simulateFill: true,
       includeTrades: false,
       seedCandleCount: 10
     })

--- a/index.js
+++ b/index.js
@@ -29,13 +29,14 @@ const execStream = async (strategy = {}, market, db, args = {}) => {
   const isTrade = args.isTrade || _isTrade
   const {
     submitOrder,
-    seedCandleCount
+    seedCandleCount,
+    backtesting,
+    simulateFill
   } = args
 
   let state = {
-    backtesting: false,
-    liveStream: true,
-
+    backtesting: backtesting || false,
+    simulateFill,
     submitOrder,
     trades: [],
     ...strategy

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-strategy-dazaar",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Dazaar logic for bfx-hf-strategy",
   "main": "./index.js",
   "author": "Bitfinex",


### PR DESCRIPTION
`simulateFill` can be used for cases where we don't submit a
generated order ourselves

### Description:
...

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [ ]

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [x] Tests added or updated
- [x] Documentation updated
